### PR TITLE
Initial implementation of Multihash

### DIFF
--- a/src/multihash.cr
+++ b/src/multihash.cr
@@ -1,5 +1,30 @@
-require "uvarint"
+# require "uvarint"
+require "./hashes"
 
-module multihash
-  # TODO
+module Multihash
+  class Multihash
+    @function_code : Int32
+
+    def initialize(hash_function : String, len : Int32, digest : String)
+      table : Hash(String, Int32) = HashFunctions::NAMES
+      @function_code = table[hash_function]
+      @len = len
+      @digest = digest
+    end
+
+    def initialize(full : String)
+      @function_code = full[0..1].to_i(16)
+      @len = full[2, 3].to_i(16)
+      @digest = full[4..-1]
+    end
+
+    def encode()
+      encoded_len = @len.to_s(16)
+      "#{@function_code.to_s(16)}#{encoded_len}#{@digest}"
+    end
+
+    def decode()
+      @digest
+    end
+  end
 end


### PR DESCRIPTION
This implements the Multihash class within the Multihash module. This
correctly uses the list of available hash functions to look up the code.

Everything in here should compile. I had to move variables around in
weird ways because crystal's type inferencer kind of sucks still.
Apparently it couldn't figure out that a Hash literal that is all String
-> Int32 is a Hash(String, Int32), or that a Hash(String, Int32) will
return an Int32 as values.

I tested this locally against my previous test cases, and it seems to
work. We should write up some real test cases though.

Fixes #3 