### PR TITLE
Refactor Multihash API and make it a struct

### DIFF
--- a/src/multihash.cr
+++ b/src/multihash.cr
@@ -2,29 +2,75 @@
 require "./hashes"
 
 module Multihash
-  class Multihash
-    @function_code : Int32
+  HEX_SIZE_IN_BYTES = 2
+  struct Multihash
+    @hash_code : Int32
+    @len : Int32
 
-    def initialize(hash_function : String, len : Int32, digest : String)
+    def initialize(hash_name : String, digest : String)
       table : Hash(String, Int32) = HashFunctions::NAMES
-      @function_code = table[hash_function]
-      @len = len
+      @hash_code = table[hash_name]
+      @len = digest.size * HEX_SIZE_IN_BYTES
       @digest = digest
     end
 
     def initialize(full : String)
-      @function_code = full[0..1].to_i(16)
-      @len = full[2, 3].to_i(16)
+      # TODO(nate): replace this with real Varint parsing
+      @hash_code = full[0..1].to_i(16)
+      @len = full[2..3].to_i(16)
       @digest = full[4..-1]
     end
 
-    def encode()
-      encoded_len = @len.to_s(16)
-      "#{@function_code.to_s(16)}#{encoded_len}#{@digest}"
+    # Accessors
+    def hash_code
+      @hash_code
     end
 
-    def decode()
+    def len
+      @len
+    end
+
+    def digest
       @digest
     end
+
+    # Serializing/encoding
+    def to_s
+      # TODO(nate): replace this with real Varint serializing
+      serialized_hash_code = @hash_code.to_s(16)
+      serialized_len = @len.to_s(16)
+      "#{serialized_hash_code}#{serialized_len}#{@digest}"
+    end
+
+    # Comparison
+    def ==(other : Multihash)
+      (@hash_code == other.hash_code &&
+       @len == other.len &&
+       @digest == other.digest)
+    end
+
+    def !=(other : Multihash)
+      !(self.==(other))
+    end
   end
+
+
+  # TODO(nate): remove this and use it as the basis for tests
+  m = Multihash.new "0011deadbeef"
+  # puts "deadbeef"
+  puts "m.code:    0x" + m.hash_code.to_s 16 # => 0x00
+  puts "m.len:     0x" + m.len.to_s 16 # => 0x11
+  puts "m.digest:  " + m.digest # => "deadbeef"
+  puts "m:         " + m.to_s
+  m2 = Multihash.new("sha1", "cafebabe")
+  puts "m2.code:   0x" + m2.hash_code.to_s 16
+  puts "m2.len:    0x" + m2.len.to_s 16
+  puts "m2.digest: " + m2.digest
+  puts "m2:        " + m2.to_s
+  # etc.
+
+  # Comparison
+  puts (m == m2) # => false
+  puts (m != m2) # => true
 end
+


### PR DESCRIPTION
This changes the Multihash API to something that's probably more useful.
You can encode a Multihash by instantiating one with the hash
name + digest, and then calling `.to_s` on the instance. You can decode
a Multihash by instantiating it with the fully-encoded digest string and
retrieving the `@len`, `@hash_code`, or `@digest` values.

It's not necessary to require the `len` value to be passed into a
constructor, so I removed that parameter. The length can be found
directly from the length of the digest string. In fact, if we allow it
to be passed in explicitly, then we're inviting inconsistent state.

This adds comparison operators (equals and not-equals), since comparing
cryptographic hashes is a common use case. It makes sense to allow
people to compare Multihashes directly, without the need to explicitly
decode them. This does not override any other operators.

Also, instead of allowing Multihash to be a mutable class, it is now an
immutable struct. Allowing instance variables to change would likely
produce an invalid state.

This also adds some example usage toward the bottom of the module. This
is not meant to stay for good, but it'll be a good start for someone to
take it out and base tests off it. Until we write tests, I think we
should keep this code here; the crystal compiler is strange in that it
sometimes lets errors slip through the cracks unless that code is
actively executed.

Fixes #7, Fixes #9